### PR TITLE
Enables support for resolver extensions for compatibility with grafast, complexity, etc.

### DIFF
--- a/.changeset/nice-eels-press.md
+++ b/.changeset/nice-eels-press.md
@@ -1,0 +1,6 @@
+---
+'graphql-modules': minor
+'website': patch
+---
+
+Enabled support for resolver extensions for compatibility with such libraries as grafast or graphql-query-complexity

--- a/packages/graphql-modules/tests/bootstrap.spec.ts
+++ b/packages/graphql-modules/tests/bootstrap.spec.ts
@@ -2,7 +2,6 @@ import 'reflect-metadata';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { createApplication, createModule, testkit, gql } from '../src';
 import { NonDocumentNodeError } from '../src/shared/errors';
-import { resolve } from 'path';
 
 test('fail when modules have non-unique ids', async () => {
   const modFoo = createModule({

--- a/website/src/content/essentials/resolvers.mdx
+++ b/website/src/content/essentials/resolvers.mdx
@@ -61,7 +61,6 @@ Next, use it to load your files dynamically:
 
 ```ts
 import { createModule } from 'graphql-modules'
-import { constant } from "grafast";
 
 export const myModule = createModule({
   id: 'my-module',

--- a/website/src/content/essentials/resolvers.mdx
+++ b/website/src/content/essentials/resolvers.mdx
@@ -60,10 +60,8 @@ npm i @graphql-tools/load-files
 Next, use it to load your files dynamically:
 
 ```ts
-import MyQueryType from './query.type.graphql'
 import { createModule } from 'graphql-modules'
-import { loadFilesSync } from '@graphql-tools/load-files'
-import { join } from 'path'
+import { constant } from "grafast";
 
 export const myModule = createModule({
   id: 'my-module',
@@ -72,3 +70,40 @@ export const myModule = createModule({
   resolvers: loadFilesSync(join(__dirname, './resolvers/*.ts'))
 })
 ```
+
+## Resolver Extensions
+
+You can use resolver extensions to extend the functionality of your resolvers to make your modules work with such extensions as [Grafast Plan Resolver](https://grafast.org/grafast/plan-resolvers#specifying-a-field-plan-resolver) or [GraphQL Query Complexity](https://github.com/slicknode/graphql-query-complexity/blob/HEAD/src/estimators/fieldExtensions/README.md).
+
+To use resolver extensions, you can use the `extensions` property in your resolvers.
+
+```ts
+import { createModule, gql } from 'graphql-modules'
+import { constant } from "grafast";
+
+export const myModule = createModule({
+  id: 'my-module',
+  dirname: __dirname,
+  typeDefs: [
+    gql`
+      type Query {
+        meaningOfLife: Int!
+      }
+    `
+  ],
+  resolvers: {
+    Query: {
+      meaningOfLife: {
+        extensions: {
+          grafast: {
+            plan() {
+              return constant(42);
+            },
+          },
+        },
+      },
+    }
+  }
+})
+```
+


### PR DESCRIPTION
## Description

This change makes it possible to use graphql-modules with resolver extensions such as grafast, graphql-query-complexity and others.

Fixes #2615

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added a test in packages/graphql-modules/tests/bootstrap.spec.ts

**Test Environment**:

- OS: masOS 15.5
- `@graphql-modules/...`: 3.0.0
- NodeJS: v24.3.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This is a pretty trivial change, but will significantly improve compatibility of graphql-modules with the rest of graphql ecosystem.